### PR TITLE
Adjust behavior of c++2py, c++2rst, c++2cxx to traverse included files

### DIFF
--- a/bin/c++2cxx
+++ b/bin/c++2cxx
@@ -19,6 +19,7 @@ parser.add_argument('--includes', '-I', action='append',  help='Includes to pass
 parser.add_argument('--system_includes', '-isystem', action='append',  help='System includes to pass to clang')
 parser.add_argument('--namespace', '-N', action='append',  help='namespaces to document', default= []) #specify which namespaces to document, e.g. -N triqs -N applications
 parser.add_argument('--cxxflags', default = '', help='Options to pass to clang')
+parser.add_argument('--target_file_only', action='store_true', help='Disable recursion into included header files')
 
 args = parser.parse_args()
 
@@ -34,7 +35,8 @@ W= Cpp2Cxx(filename = args.filename,
             includes = args.includes or (), 
             system_includes = args.system_includes or (),
             compiler_options = args.cxxflags.split(' ') + cxx_env,
-            libclang_location = args.libclang_location
+            libclang_location = args.libclang_location,
+            target_file_only = args.target_file_only
             )
 
 filename_1 = os.path.split(args.filename)[1].split('.',1)[0]

--- a/bin/c++2py
+++ b/bin/c++2py
@@ -36,6 +36,7 @@ parser.add_argument('--libclang_location', help='Location of the libclang', defa
 parser.add_argument('--includes', '-I', action='append',  help='Includes to pass to clang')
 parser.add_argument('--system_includes', '-isystem', action='append',  help='System includes to pass to clang')
 parser.add_argument('--cxxflags', default = '', help='Options to pass to clang')
+parser.add_argument('--target_file_only', action='store_true', help='Disable recursion into included header files')
 
 args = parser.parse_args()
 
@@ -75,7 +76,8 @@ W= Cpp2Desc(filename = args.filename,
             libclang_location = args.libclang_location,
             shell_command = shell_command,
             parse_all_comments = args.parse_all_comments,
-            namespace_to_factor= () # unused now  
+            namespace_to_factor= (), # unused now
+            target_file_only = args.target_file_only
             )
 
 # Make the desc file

--- a/bin/c++2rst
+++ b/bin/c++2rst
@@ -16,6 +16,7 @@ parser.add_argument('--system_includes', '-isystem', action='append',  help='Sys
 parser.add_argument('--namespace', '-N', action='append',  help='namespaces to document', default= []) #specify which namespaces to document, e.g. -N triqs -N applications
 parser.add_argument('--parse-all-comments',  action='store_true', help="Grab all comments, including non doxygen like [FALSE]")
 parser.add_argument('--cxxflags', default = '', help='Options to pass to clang')
+parser.add_argument('--target_file_only', action='store_true', help='Disable recursion into included header files')
 
 args = parser.parse_args()
 args.includes = (args.includes or [])
@@ -35,7 +36,8 @@ W= Cpp2Rst(filename = args.filename,
             system_includes = args.system_includes or (),
             compiler_options = args.cxxflags.split(' ') + cxx_env,
             parse_all_comments = args.parse_all_comments,
-            libclang_location = args.libclang_location
+            libclang_location = args.libclang_location,
+            target_file_only = args.target_file_only
             )
 
 # profile for testing

--- a/cpp2cxx/cpp2cxx.py
+++ b/cpp2cxx/cpp2cxx.py
@@ -4,7 +4,7 @@ import cpp2py.clang_parser as CL
 
 class Cpp2Cxx: 
     """ """
-    def __init__(self, filename, namespaces=(), compiler_options=None, includes = None, system_includes = None, parse_all_comments = False, libclang_location = None):
+    def __init__(self, filename, namespaces=(), compiler_options=None, includes = None, system_includes = None, libclang_location = None, parse_all_comments = False, target_file_only = False):
         """
            Parse the file at construction
            
@@ -28,19 +28,25 @@ class Cpp2Cxx:
            
            libclang_location : string, optional
                       Absolute path to libclang. By default, the detected one.
+
+           parse_all_comments : bool
+                      Grab all comments, including non doxygen like [default = False]
+
+           target_file_only : bool
+                      Neglect any included files during desc generation [default = False]
         """
-        self.filename, self.namespaces = filename, namespaces
+        self.filename, self.namespaces, self.target_file_only = filename, namespaces, target_file_only
         self.root = CL.parse(filename, compiler_options, includes, system_includes, libclang_location, parse_all_comments, skip_function_bodies = False)
 
     # FIXME : pass the 3 functions to run functions ?? 
     # default : namespace, filelocation, ?
     # lambda ns : this_condition(ns) or ... easy to add...
     def keep_ns(self, n):
-        if n.location.file.name != self.filename: return False
+        if (target_file_only and n.location.file.name != self.filename): return False
         return len(self.namespaces) == 0 or n.spelling in self.namespaces
     
     def keep_cls(self, c):
-        if c.location.file.name != self.filename: return False
+        if (target_file_only and c.location.file.name != self.filename): return False
         return True
     
     def all_classes_gen(self):

--- a/cpp2py/cpp2desc.py
+++ b/cpp2py/cpp2desc.py
@@ -8,7 +8,7 @@ class Cpp2Desc:
     """ """
     def __init__(self, filename, namespaces=(), classes= (), namespace_to_factor= (), appname= '', 
                  modulename = '', moduledoc ='', use_properties = False, members_read_only = True,  converters = (),
-                 compiler_options=None, includes= None, system_includes= None, libclang_location = None, shell_command = '', parse_all_comments = True):
+                 compiler_options=None, includes= None, system_includes= None, libclang_location = None, shell_command = '', parse_all_comments = True, target_file_only = False):
         """
            Parse the file at construction
            
@@ -31,16 +31,16 @@ class Cpp2Desc:
                       Name of the module
            
            moduledoc : string
-                       Documentation of the module
+                      Documentation of the module
 
            shell_command : string
-                           script command that was called (to regenerate the desc file)
+                      script command that was called (to regenerate the desc file)
 
            use_properties : Boolean
-                            Transform method with no args into property
+                      Transform method with no args into property
 
            members_read_only : Boolean
-                               The members are wrapped "read only"
+                      The members are wrapped "read only"
 
            includes : string, optional
                       Additional includes to add (-I xxx) for clang
@@ -53,9 +53,15 @@ class Cpp2Desc:
            
            libclang_location : string, optional
                       Absolute path to libclang. By default, the detected one.
+
+           parse_all_comments : bool
+                      Grab all comments, including non doxygen like [default = True]
+
+           target_file_only : bool
+                      Neglect any included files during desc generation [default = False]
         """
         for x in ['filename', 'namespaces', 'classes', 'namespace_to_factor', 'appname', 'modulename', 'moduledoc', 
-                  'use_properties', 'members_read_only', 'shell_command']:
+                  'use_properties', 'members_read_only', 'shell_command', 'target_file_only']:
             setattr(self, x, locals()[x])
         self.DE = dependency_analyzer.DependencyAnalyzer(converters)
         # parse the file
@@ -75,15 +81,15 @@ class Cpp2Desc:
            The filter to keep a class/struct or an enum : 
             if we a namespace list, it must be in it. 
             if we have an explicit self.classes : c must be into it
-            else it has to be in the file given to c++2py 
+            if target_file_only it has to be in the file given to c++2py
         """
         if CL.is_template(c) or ("ignore_in_python" in CL.get_annotations(c)): return False
         if self.namespaces:
-            ns = CL.get_namespace(c) 
-            if not any((x in ns) for x in self.namespaces) : return False
+            qualified_ns = CL.get_namespace(c)
+            if not any((x in qualified_ns) for x in self.namespaces) : return False
         if self.classes: 
             return c.spelling in self.classes or CL.fully_qualified(c) in self.classes
-        return c.location.file.name == self.filename
+        return (c.location.file.name == self.filename) if self.target_file_only else True
         
     def keep_fnt(self, f):
         # Same as class, but eliminate operator, begin, end.

--- a/cpp2rst/cpp2rst.py
+++ b/cpp2rst/cpp2rst.py
@@ -29,7 +29,7 @@ def mkchdir(*subdirs):
 
 class Cpp2Rst: 
     """ """
-    def __init__(self, filename, namespaces=(), compiler_options=None, includes=None, system_includes=None, parse_all_comments = False, libclang_location = None):
+    def __init__(self, filename, namespaces=(), compiler_options=None, includes=None, system_includes=None, libclang_location = None, parse_all_comments = False, Target_file_only = False):
         """
            Parse the file at construction
            
@@ -53,8 +53,14 @@ class Cpp2Rst:
            
            libclang_location : string, optional
                       Absolute path to libclang. By default, the detected one.
+
+           parse_all_comments : bool
+                      Grab all comments, including non doxygen like [default = False]
+
+           target_file_only : bool
+                      Neglect any included files during desc generation [default = False]
         """
-        self.filename, self.namespaces = filename, namespaces
+        self.filename, self.namespaces, self.target_file_only = filename, namespaces, target_file_only
         self.root = CL.parse(filename, compiler_options, includes, system_includes, libclang_location, parse_all_comments)
 
     # ------------------------
@@ -72,14 +78,17 @@ class Cpp2Rst:
             return any((ns in x) for x in self.namespaces)
         
         def keep_cls(c):
-            """Keeps the class if its namespace is EXACTLY in self.namespaces
-               e.g. A::B::cls will be kept iif A::B is in self.namespaces, not it A is.
+            """
+               The filter to keep a class/struct or an enum :
+                 it must have a raw comment
+                 if we a namespace list, it must be in it.
+                 if target_file_only it has to be in the file given to c++2py
             """
             if not c.raw_comment : return False
-            if len(self.namespaces)>0 :
-                ns = CL.fully_qualified(c.referenced).rsplit('::',1)[0]
-                return ns in self.namespaces
-            return True
+            if self.namespaces:
+                qualified_ns = CL.get_namespace(c) 
+                if not any((x in qualified_ns) for x in self.namespaces) : return False
+            return (c.location.file.name == self.filename) if self.target_file_only else True
         
         def keep_fnt(f) :
             if not f.raw_comment : return False
@@ -87,7 +96,7 @@ class Cpp2Rst:
             return keep_cls(f)
 
         # A list of AST nodes for classes
-        classes =CL.get_classes(self.root, keep_cls, traverse_namespaces = True, keep_ns = keep_ns)
+        classes = CL.get_classes(self.root, keep_cls, traverse_namespaces = True, keep_ns = keep_ns)
         classes = list(classes) # to avoid exhaustion of the generator
    
         # A list of AST nodes for the methods and functions


### PR DESCRIPTION
This commits adjusts the behavior of all the executables to traverse (recursively) any included headers.
It adds an option --target_file_only to disable recursion.