### PR TITLE
include stl header for gcc compilation

### DIFF
--- a/include/cpp2py/py_converter.hpp
+++ b/include/cpp2py/py_converter.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <complex>
 #include <map>
+#include <memory>
 #include <typeindex>
 #include <exception>
 #include <iostream>


### PR DESCRIPTION
I was compiling h5 (github.com/TRIQS/h5), using gcc 9.4.0 and making all deps from scratch. 

When building cpp2py, the following error was raised

```
error: 'shared_ptr' in namespace 'std' does not name a template type
   50 |   static std::shared_ptr<conv_table_t> conv_table_sptr = {};
      |               ^~~~~~~~~~
In file included from /mnt/home/pdumitrescu/Documents/coding/repos/h5/build/deps/Cpp2Py_src/include/cpp2py.hpp:11,
                 from /mnt/home/pdumitrescu/Documents/coding/repos/h5/python/h5/h5py_io.cpp:10:
/mnt/home/pdumitrescu/Documents/coding/repos/h5/build/deps/Cpp2Py_src/include/./cpp2py/py_converter.hpp:8:1: note: 'std::shared_ptr' is defined in header '<memory>'; did you forget to '#include <memory>'?
    7 | #include <typeindex>
  +++ |+#include <memory>
    8 | #include <exception>
```

This PR is the obvious fix that gcc suggests.

See also the PR (https://github.com/TRIQS/h5/pull/1) for a similar issue.