### PR TITLE
NPY Scalar Conversion

### DIFF
--- a/c++/cpp2py/converters/basic_types.hpp
+++ b/c++/cpp2py/converters/basic_types.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "./../pyref.hpp"
+#include "../pyref.hpp"
 #include "./complex.hpp"
 
 #include <numpy/arrayobject.h>
@@ -24,7 +24,7 @@ namespace cpp2py {
     static bool py2c(PyObject *ob) { return ob == Py_True; }
     static bool is_convertible(PyObject *ob, bool raise_exception) {
       if (PyBool_Check(ob)) return true;
-      if (raise_exception) { PyErr_SetString(PyExc_TypeError, "Cannot convert to bool"); }
+      if (raise_exception) { PyErr_SetString(PyExc_TypeError, ("Cannot convert "s + to_string(ob) + " to bool"s).c_str()); }
       return false;
     }
   };
@@ -46,7 +46,7 @@ namespace cpp2py {
           pyref py_arr = PyArray_FromScalar(ob, NULL);
           if (PyArray_ISINTEGER((PyObject *)py_arr)) return true;
         }
-        if (raise_exception) { PyErr_SetString(PyExc_TypeError, "Cannot convert to integer type"); }
+        if (raise_exception) { PyErr_SetString(PyExc_TypeError, ("Cannot convert "s + to_string(ob) + " to integer type"s).c_str()); }
         return false;
       }
     };
@@ -74,7 +74,7 @@ namespace cpp2py {
         pyref py_arr = PyArray_FromScalar(ob, NULL);
         if (PyArray_ISINTEGER((PyObject*)py_arr) or PyArray_ISFLOAT((PyObject*)py_arr)) return true;
       }
-      if (raise_exception) { PyErr_SetString(PyExc_TypeError, "Cannot convert to double"); }
+      if (raise_exception) { PyErr_SetString(PyExc_TypeError, ("Cannot convert "s + to_string(ob) + " to double"s).c_str()); }
       return false;
     }
   };

--- a/c++/cpp2py/converters/complex.hpp
+++ b/c++/cpp2py/converters/complex.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include "./../pyref.hpp"
+#include "../pyref.hpp"
 
 #include <numpy/arrayobject.h>
 
@@ -34,7 +34,7 @@ namespace cpp2py {
         pyref py_arr = PyArray_FromScalar(ob, NULL);
         if (PyArray_ISINTEGER((PyObject*)py_arr) or PyArray_ISFLOAT((PyObject*)py_arr) or PyArray_ISCOMPLEX((PyObject*)py_arr)) return true;
       }
-      if (raise_exception) { PyErr_SetString(PyExc_TypeError, "Cannot convert to complex"); }
+      if (raise_exception) { PyErr_SetString(PyExc_TypeError, ("Cannot convert "s + to_string(ob) + " to complex"s).c_str()); }
       return false;
     }
   };

--- a/c++/cpp2py/converters/complex.hpp
+++ b/c++/cpp2py/converters/complex.hpp
@@ -1,5 +1,7 @@
 #pragma once
-#include <Python.h>
+#include "./../pyref.hpp"
+
+#include <numpy/arrayobject.h>
 
 namespace cpp2py {
 
@@ -8,6 +10,18 @@ namespace cpp2py {
   template <> struct py_converter<std::complex<double>> {
     static PyObject *c2py(std::complex<double> x) { return PyComplex_FromDoubles(x.real(), x.imag()); }
     static std::complex<double> py2c(PyObject *ob) {
+
+      if (PyArray_CheckScalar(ob)) {
+        // Convert NPY Scalar Type to Builtin Type
+        pyref py_builtin = PyObject_CallMethod(ob, "item", NULL);
+        if (PyComplex_Check(py_builtin)) {
+          auto r = PyComplex_AsCComplex(py_builtin);
+          return {r.real, r.imag};
+        } else {
+          return PyFloat_AsDouble(py_builtin);
+        }
+      }
+
       if (PyComplex_Check(ob)) {
         auto r = PyComplex_AsCComplex(ob);
         return {r.real, r.imag};
@@ -16,6 +30,10 @@ namespace cpp2py {
     }
     static bool is_convertible(PyObject *ob, bool raise_exception) {
       if (PyComplex_Check(ob) || PyFloat_Check(ob) || PyLong_Check(ob)) return true;
+      if (PyArray_CheckScalar(ob)) {
+        pyref py_arr = PyArray_FromScalar(ob, NULL);
+        if (PyArray_ISINTEGER((PyObject*)py_arr) or PyArray_ISFLOAT((PyObject*)py_arr) or PyArray_ISCOMPLEX((PyObject*)py_arr)) return true;
+      }
       if (raise_exception) { PyErr_SetString(PyExc_TypeError, "Cannot convert to complex"); }
       return false;
     }

--- a/c++/cpp2py/converters/function.hpp
+++ b/c++/cpp2py/converters/function.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <functional>
+#include "./../misc.hpp"
 
 namespace cpp2py {
 
@@ -185,6 +186,9 @@ namespace cpp2py {
       pyref py_fnt = borrowed(ob);
       auto l       = [py_fnt](T... x) mutable -> R { // py_fnt is a pyref, it will keep the ref and manage the ref counting...
         pyref ret  = PyObject_CallFunctionObjArgs(py_fnt, (PyObject *)pyref(convert_to_python(x))..., NULL);
+        if (not py_converter<R>::is_convertible(ret, false)) {
+          CPP2PY_RUNTIME_ERROR << "\n Cannot convert function result " << to_string(ret) << " from python to C++";
+        }
         return py_converter<R>::py2c(ret);
       };
       return l;

--- a/c++/cpp2py/converters/function.hpp
+++ b/c++/cpp2py/converters/function.hpp
@@ -1,6 +1,6 @@
 #pragma once
 #include <functional>
-#include "./../misc.hpp"
+#include "../pyref.hpp"
 
 namespace cpp2py {
 
@@ -172,7 +172,7 @@ namespace cpp2py {
 
     static bool is_convertible(PyObject *ob, bool raise_exception) {
       if (PyCallable_Check(ob)) return true;
-      if (raise_exception) { PyErr_SetString(PyExc_TypeError, "Cannot convert to std::function a non callable object"); }
+      if (raise_exception) { PyErr_SetString(PyExc_TypeError, ("Cannot convert "s + to_string(ob) + " std::function as it is not callable"s).c_str()); }
       return false;
     }
 

--- a/c++/cpp2py/converters/map.hpp
+++ b/c++/cpp2py/converters/map.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <map>
 #include "../traits.hpp"
+#include "../pyref.hpp"
 
 namespace cpp2py {
 
@@ -46,7 +47,7 @@ namespace cpp2py {
         return true;
       }
     _false:
-      if (raise_exception) { PyErr_SetString(PyExc_TypeError, "Cannot convert to std::map"); }
+      if (raise_exception) { PyErr_SetString(PyExc_TypeError, ("Cannot convert "s + to_string(ob) + " to std::map"s).c_str()); }
       return false;
     }
 

--- a/c++/cpp2py/converters/pair.hpp
+++ b/c++/cpp2py/converters/pair.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include "../traits.hpp"
+#include "../pyref.hpp"
 
 namespace cpp2py {
 
@@ -23,7 +24,7 @@ namespace cpp2py {
         return true;
       }
     _false:
-      if (raise_exception) { PyErr_SetString(PyExc_TypeError, "Cannot convert to std::pair"); }
+      if (raise_exception) { PyErr_SetString(PyExc_TypeError, ("Cannot convert "s + to_string(ob) + " to std::pair"s).c_str()); }
       return false;
     }
 

--- a/c++/cpp2py/converters/set.hpp
+++ b/c++/cpp2py/converters/set.hpp
@@ -1,6 +1,7 @@
 #pragma once
 #include <set>
 #include "../traits.hpp"
+#include "../pyref.hpp"
 
 namespace cpp2py {
 
@@ -35,7 +36,7 @@ namespace cpp2py {
         return true;
       }
     _false:
-      if (raise_exception) { PyErr_SetString(PyExc_TypeError, "Cannot convert to std::set"); }
+      if (raise_exception) { PyErr_SetString(PyExc_TypeError, ("Cannot convert "s + to_string(ob) + " to std::set"s).c_str()); }
       return false;
     }
 

--- a/c++/cpp2py/converters/std_array.hpp
+++ b/c++/cpp2py/converters/std_array.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <array>
+#include "../pyref.hpp"
 
 namespace cpp2py {
 
@@ -39,7 +40,7 @@ namespace cpp2py {
         return true;
       }
     _false:
-      if (raise_exception) { PyErr_SetString(PyExc_TypeError, "Cannot convert to std::array"); }
+      if (raise_exception) { PyErr_SetString(PyExc_TypeError, ("Cannot convert "s + to_string(ob) + " to std::array"s).c_str()); }
       return false;
     }
 

--- a/c++/cpp2py/converters/string.hpp
+++ b/c++/cpp2py/converters/string.hpp
@@ -1,5 +1,5 @@
 #pragma once
-//#include <string>
+#include "../pyref.hpp"
 
 namespace cpp2py {
 
@@ -11,7 +11,7 @@ namespace cpp2py {
 
     static bool is_convertible(PyObject *ob, bool raise_exception) {
       if (PyUnicode_Check(ob) or PyUnicode_Check(ob)) return true;
-      if (raise_exception) { PyErr_SetString(PyExc_TypeError, "Cannot convert to string"); }
+      if (raise_exception) { PyErr_SetString(PyExc_TypeError, ("Cannot convert "s + to_string(ob) + " to string"s).c_str()); }
       return false;
     }
   };
@@ -24,7 +24,7 @@ namespace cpp2py {
 
     static bool is_convertible(PyObject *ob, bool raise_exception) {
       if (PyUnicode_Check(ob) and PyUnicode_GET_LENGTH(ob) == 1) return true;
-      if (raise_exception) { PyErr_SetString(PyExc_TypeError, "Cannot convert to char"); }
+      if (raise_exception) { PyErr_SetString(PyExc_TypeError, ("Cannot convert "s + to_string(ob) + " to char"s).c_str()); }
       return false;
     }
   };
@@ -37,7 +37,7 @@ namespace cpp2py {
 
     static bool is_convertible(PyObject *ob, bool raise_exception) {
       if (PyBytes_Check(ob) and PyBytes_Size(ob) == 1) return true;
-      if (raise_exception) { PyErr_SetString(PyExc_TypeError, "Cannot convert to unsigned char"); }
+      if (raise_exception) { PyErr_SetString(PyExc_TypeError, ("Cannot convert "s + to_string(ob) + " to unsigned char"s).c_str()); }
       return false;
     }
   };
@@ -50,7 +50,7 @@ namespace cpp2py {
 
     static bool is_convertible(PyObject *ob, bool raise_exception) {
       if (PyUnicode_Check(ob)) return true;
-      if (raise_exception) { PyErr_SetString(PyExc_TypeError, "Cannot convert to string"); }
+      if (raise_exception) { PyErr_SetString(PyExc_TypeError, ("Cannot convert "s + to_string(ob) + " to string"s).c_str()); }
       return false;
     }
   };

--- a/c++/cpp2py/converters/tuple.hpp
+++ b/c++/cpp2py/converters/tuple.hpp
@@ -4,6 +4,7 @@
 #include <numeric>
 
 #include "../traits.hpp"
+#include "../pyref.hpp"
 
 namespace cpp2py {
 
@@ -37,13 +38,13 @@ namespace cpp2py {
     public:
     static bool is_convertible(PyObject *ob, bool raise_exception) {
       if (not PySequence_Check(ob)) {
-        if (raise_exception) { PyErr_SetString(PyExc_TypeError, "Cannot convert non-sequence to std::tuple"); }
+        if (raise_exception) { PyErr_SetString(PyExc_TypeError, ("Cannot convert "s + to_string(ob) + " to std::tuple as it is not a sequence"s).c_str()); }
         return false;
       }
       pyref seq = PySequence_Fast(ob, "expected a sequence");
       // Sizes must match! Could we relax this condition to '<'?
       if (PySequence_Fast_GET_SIZE((PyObject *)seq) != std::tuple_size<tuple_t>::value) {
-        if (raise_exception) { PyErr_SetString(PyExc_TypeError, "Cannot convert to std::tuple due to improper length"); }
+        if (raise_exception) { PyErr_SetString(PyExc_TypeError, ("Cannot convert "s + to_string(ob) + " to std::tuple due to improper length"s).c_str()); }
         return false;
       }
       return is_convertible_impl((PyObject *)seq, raise_exception, std::make_index_sequence<sizeof...(Types)>());

--- a/c++/cpp2py/converters/variant.hpp
+++ b/c++/cpp2py/converters/variant.hpp
@@ -3,6 +3,7 @@
 #include <variant>
 
 #include "../traits.hpp"
+#include "../pyref.hpp"
 
 namespace cpp2py {
 
@@ -58,7 +59,7 @@ namespace cpp2py {
 
     static bool is_convertible(PyObject *ob, bool raise_exception) {
       if ((... or py_converter<std::decay_t<T>>::is_convertible(ob, false))) return true;
-      if (raise_exception) { PyErr_SetString(PyExc_TypeError, "Cannot convert to std::variant"); }
+      if (raise_exception) { PyErr_SetString(PyExc_TypeError, ("Cannot convert "s + to_string(ob) + " to std::variant"s).c_str()); }
       return false;
     }
 

--- a/c++/cpp2py/converters/vector.hpp
+++ b/c++/cpp2py/converters/vector.hpp
@@ -4,6 +4,7 @@
 #include <numpy/arrayobject.h>
 
 #include "../traits.hpp"
+#include "../pyref.hpp"
 #include "../macros.hpp"
 #include "../numpy_proxy.hpp"
 
@@ -92,7 +93,7 @@ namespace cpp2py {
       }
 
       if (!PySequence_Check(ob)) {
-        if (raise_exception) { PyErr_SetString(PyExc_TypeError, "Cannot convert a non-sequence to std::vector"); }
+        if (raise_exception) { PyErr_SetString(PyExc_TypeError, ("Cannot convert "s + to_string(ob) + " to std::vector as it is not a sequence"s).c_str()); }
         return false;
       }
 

--- a/c++/cpp2py/misc.hpp
+++ b/c++/cpp2py/misc.hpp
@@ -13,11 +13,6 @@
 
 namespace cpp2py {
 
-  inline std::string to_string(PyObject * ob){
-    pyref py_str = PyObject_Str(ob);
-    return PyUnicode_AsUTF8(py_str);
-  }
-
   inline char *get_current_time() { // helper function to print the time in the CATCH_AND_RETURN macro
     time_t rawtime;
     time(&rawtime);

--- a/c++/cpp2py/misc.hpp
+++ b/c++/cpp2py/misc.hpp
@@ -1,6 +1,8 @@
 #pragma once
 #include <vector>
+#include <string>
 #include "./exceptions.hpp"
+#include "./pyref.hpp"
 #include <time.h>
 
 // silence warning on intel
@@ -10,6 +12,11 @@
 #pragma GCC diagnostic ignored "-Wwrite-strings"
 
 namespace cpp2py {
+
+  inline std::string to_string(PyObject * ob){
+    pyref py_str = PyObject_Str(ob);
+    return PyUnicode_AsUTF8(py_str);
+  }
 
   inline char *get_current_time() { // helper function to print the time in the CATCH_AND_RETURN macro
     time_t rawtime;

--- a/c++/cpp2py/py_converter.hpp
+++ b/c++/cpp2py/py_converter.hpp
@@ -4,6 +4,7 @@
 
 #include "./get_module.hpp"
 #include "./macros.hpp"
+#include "./pyref.hpp"
 
 #include <string>
 #include <complex>
@@ -246,7 +247,7 @@ namespace cpp2py {
 
     static bool is_convertible(PyObject *ob, bool raise_exception) {
       if (conv_t::is_convertible(ob, false)) return true;
-      if (raise_exception) { PyErr_SetString(PyExc_TypeError, "Cannot convert to ... failed"); }
+      if (raise_exception) { PyErr_SetString(PyExc_TypeError, ("Cannot convert "s + to_string(ob) + " to ... failed"s).c_str()); }
       return false;
     }
 
@@ -267,7 +268,7 @@ namespace cpp2py {
 
     static bool is_convertible(PyObject *ob, bool raise_exception) {
       if (conv_t::is_convertible(ob, false)) return true;
-      if (raise_exception) { PyErr_SetString(PyExc_TypeError, "Cannot convert to ... failed"); }
+      if (raise_exception) { PyErr_SetString(PyExc_TypeError, ("Cannot convert "s + to_string(ob) + " to ... failed"s).c_str()); }
       return false;
     }
 

--- a/c++/cpp2py/pyref.hpp
+++ b/c++/cpp2py/pyref.hpp
@@ -4,6 +4,7 @@
 #include "./get_module.hpp"
 
 #include <string>
+using namespace std::string_literals;
 
 namespace cpp2py {
 
@@ -140,4 +141,10 @@ namespace cpp2py {
     Py_XINCREF(ob);
     return {ob};
   }
+
+  inline std::string to_string(PyObject * ob){
+    pyref py_str = PyObject_Str(ob);
+    return PyUnicode_AsUTF8(py_str);
+  }
+
 } // namespace cpp2py


### PR DESCRIPTION
This commit extend the functions `is_convertible` and `py2c` for integer and double to properly treat numpy scalar types.
