### PR TITLE
fix: check if python int type is in bounds of c++ type and protect error fetching

### DIFF
--- a/cpp2py/mako/wrap.cxx
+++ b/cpp2py/mako/wrap.cxx
@@ -615,7 +615,11 @@ template <> struct py_converter<${en.c_name}> {
       err_list = err_list + "\n" + overloads_signatures[i] + " \n failed with the error : \n  ";
       // check if error is not NULL and can be converted at all
       // otherwise unconvertible erros can lead to SegFaults
-      if (errors[i] and PyUnicode_Check((PyObject *)errors[i])) { err_list += PyUnicode_AsUTF8((PyObject *)errors[i]); }
+      if (errors[i] and PyUnicode_Check((PyObject *)errors[i])) {
+        err_list += PyUnicode_AsUTF8((PyObject *)errors[i]);
+      } else {
+        err_list += "Error message was not convertible to raw string.";
+      }
       err_list += "\n";
      }
     PyErr_SetString(PyExc_TypeError,err_list.c_str());


### PR DESCRIPTION
There was no check if the Python int type object would be in bounds of the c++ type converted to. Example: Converting 1e10 from python to C++ int would result in very weird behavior, because C++ int max is 1.xxx9.  

Additionally the protection against non convertible errors in wrap.cxx was not sufficient leading to seg faults in certain cases. 

Both should be fixed with this PR.