### PR TITLE
Add newline at end of generated desc file

### DIFF
--- a/cpp2py/cpp2desc.py
+++ b/cpp2py/cpp2desc.py
@@ -312,4 +312,4 @@ class Cpp2Desc:
         tpl = Template(filename= util.script_path() + '/mako/desc.py', strict_undefined = True)
         rendered = tpl.render(W = self, CL = CL, doc = doc, util = util,
                               import_list = import_list, converters_list = converters_list, using_list = list(self.namespaces) + list(self.namespace_to_factor))
-        open(output_filename, "w").write(util.clean_end_and_while_char(rendered))
+        open(output_filename, "w").write(util.clean_end_and_while_char(rendered) + "\n")


### PR DESCRIPTION
Several programs complain about `No newline at end of file` in generated `_desc.py` files.