### PR TITLE
[cmake] Use Python::Module instead of Python::Python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ set(LIBCLANG_LOCATION "${LIBCLANG_LOCATION}" CACHE STRING "Location of the libcl
 #--------------------------------------------------------
 message(STATUS "-------- Python detection -------------")
 
-find_package(Python REQUIRED COMPONENTS Interpreter Development NumPy)
+find_package(Python REQUIRED COMPONENTS Interpreter Development.Module NumPy)
 
 # check required python packages
 function(exec_python_command command_str output_var_name)
@@ -108,7 +108,7 @@ message(STATUS "Python modules install path: ${CMAKE_INSTALL_PREFIX}/${CPP2PY_PY
 # define the python_and_numpy interface target
 add_library(python_and_numpy INTERFACE)
 add_library(cpp2py::python_and_numpy ALIAS python_and_numpy)
-target_link_libraries(python_and_numpy INTERFACE Python::Python Python::NumPy)
+target_link_libraries(python_and_numpy INTERFACE Python::Module Python::NumPy)
 install(TARGETS python_and_numpy EXPORT Cpp2PyTargets)
 
 # set numpy related macros (C API changed with v1.7.0)


### PR DESCRIPTION
The Python::Python target is intended for embedding the entire Python interpreter into an application, whereas Python::Module is the correct target to link against when building a C extension [^1].

In principle one can also use Python::Python to build C extensions, but this has some unforseen consequences.  First of all, this target explicitly links to the libpython.so that has been detected by CMake and also adds the corresponding directory to the binary's RUNPATH.  If that directory contains other libraries, e.g. HDF5 in the case of the Anaconda distribution, then import triqs will fail with some cryptic errors about mismatched GLIBC symbol versions, because it tries to load a different HDF5 then it was compiled against.

The Python::Module target works around this by simply not linking against libpython.so, because a C extension will always run within the context of an existing Python interpreter which has all of the necessary symbols mapped into its address space in the first place.  Before Cpp2Py switched to CMake's builtin FindPython module this was indeed done manually on macOS, where the python_and_numpy target was not linked against libpython.so but instead used the linker option -undefined dynamic_lookup, which is what Python::Module abstracts.

[^1]: https://cmake.org/cmake/help/latest/module/FindPython.html